### PR TITLE
Better detection for supported pixel formats

### DIFF
--- a/xprs/xprsDecoder.cpp
+++ b/xprs/xprsDecoder.cpp
@@ -69,6 +69,20 @@ XprsResult CVideoDecoder::init(bool disableHwAcceleration) {
 }
 
 #ifdef __APPLE__
+
+// kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange and
+// kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange were introduced in macOS 15.0 / iOS 18.0 SDK
+#if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000) ||   \
+    (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000) || \
+    (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= 180000) ||         \
+    (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && __WATCH_OS_VERSION_MAX_ALLOWED >= 110000)
+#define XPRS_HAS_422_BIPLANAR_FORMATS 1
+#define XPRS_HAS_444_BIPLANAR_FORMATS 1
+#else
+#define XPRS_HAS_422_BIPLANAR_FORMATS 0
+#define XPRS_HAS_444_BIPLANAR_FORMATS 0
+#endif
+
 static PixelFormat convertVideoToolboxPixelFormat(OSType videotoolboxFormat) {
   switch (videotoolboxFormat) {
     case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
@@ -79,12 +93,16 @@ static PixelFormat convertVideoToolboxPixelFormat(OSType videotoolboxFormat) {
     case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange:
     case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange:
       return PixelFormat::NV1210LE;
+#if XPRS_HAS_422_BIPLANAR_FORMATS
     case kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange:
     case kCVPixelFormatType_422YpCbCr8BiPlanarFullRange:
       return PixelFormat::YUV422P;
+#endif
+#if XPRS_HAS_444_BIPLANAR_FORMATS
     case kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange:
     case kCVPixelFormatType_444YpCbCr8BiPlanarFullRange:
       return PixelFormat::YUV444P;
+#endif
     default:
       return PixelFormat::UNKNOWN;
   }
@@ -113,11 +131,16 @@ void CVideoDecoder::convertAVFrame(const AVFrame* avframe, Frame& frameOut) {
   if (pixelFormat != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange &&
       pixelFormat != kCVPixelFormatType_420YpCbCr8BiPlanarFullRange &&
       pixelFormat != kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange &&
-      pixelFormat != kCVPixelFormatType_420YpCbCr10BiPlanarFullRange &&
-      pixelFormat != kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange &&
-      pixelFormat != kCVPixelFormatType_422YpCbCr8BiPlanarFullRange &&
-      pixelFormat != kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange &&
-      pixelFormat != kCVPixelFormatType_444YpCbCr8BiPlanarFullRange) {
+      pixelFormat != kCVPixelFormatType_420YpCbCr10BiPlanarFullRange
+#if XPRS_HAS_422_BIPLANAR_FORMATS
+      && pixelFormat != kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange &&
+      pixelFormat != kCVPixelFormatType_422YpCbCr8BiPlanarFullRange
+#endif
+#if XPRS_HAS_444_BIPLANAR_FORMATS
+      && pixelFormat != kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange &&
+      pixelFormat != kCVPixelFormatType_444YpCbCr8BiPlanarFullRange
+#endif
+  ) {
     return;
   }
 
@@ -135,17 +158,24 @@ void CVideoDecoder::convertAVFrame(const AVFrame* avframe, Frame& frameOut) {
   // Default to 420 format
   size_t uvHeight = height / 2;
   size_t frameSize = width * height * 3 / 2;
+#if XPRS_HAS_422_BIPLANAR_FORMATS
   if (pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange ||
       pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarFullRange) {
     // 422 doubles vertical chroma samples compared to 420
     frameSize = width * height * 2;
     uvHeight = height;
-  } else if (
-      pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange ||
-      pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarFullRange) {
+  } else
+#endif
+#if XPRS_HAS_444_BIPLANAR_FORMATS
+      if (pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange ||
+          pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarFullRange) {
     // 444 doubles both vertical and horizontal chroma samples compared to 420
     frameSize = width * height * 3;
     uvHeight = height;
+  } else
+#endif
+  {
+    // 420 format - use default values above
   }
   frameSize *= bytes;
   if (_buffer.size() < frameSize) {
@@ -160,6 +190,7 @@ void CVideoDecoder::convertAVFrame(const AVFrame* avframe, Frame& frameOut) {
     }
 
     // Convert biplanar 422 and 444 to triplanar
+#if XPRS_HAS_422_BIPLANAR_FORMATS
     if (pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange ||
         pixelFormat == kCVPixelFormatType_422YpCbCr8BiPlanarFullRange) {
       uint8_t* uvPlane = (uint8_t*)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1);
@@ -179,9 +210,11 @@ void CVideoDecoder::convertAVFrame(const AVFrame* avframe, Frame& frameOut) {
       frameOut.planes[2] = vPlane;
       frameOut.stride[2] = width / 2;
 
-    } else if (
-        pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange ||
-        pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarFullRange) {
+    } else
+#endif
+#if XPRS_HAS_444_BIPLANAR_FORMATS
+        if (pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange ||
+            pixelFormat == kCVPixelFormatType_444YpCbCr8BiPlanarFullRange) {
       uint8_t* uvPlane = (uint8_t*)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1);
       uint8_t* uPlane = _buffer.data() + width * height;
       uint8_t* vPlane = uPlane + (width * height);
@@ -197,7 +230,9 @@ void CVideoDecoder::convertAVFrame(const AVFrame* avframe, Frame& frameOut) {
       frameOut.stride[1] = width;
       frameOut.planes[2] = vPlane;
       frameOut.stride[2] = width;
-    } else {
+    } else
+#endif
+    {
       // Copy the UV plane for NV12
       uint8_t* uvPlane = (uint8_t*)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1);
       for (size_t y = 0; y < uvHeight; y++) {


### PR DESCRIPTION
Summary: Both XPRS_HAS_422_BIPLANAR_FORMATS and XPRS_HAS_444_BIPLANAR_FORMATS have been introduced with SDK version (macOS 15.0 / iOS 18.0) -- we are here testing at compile time if they are or not available.

Differential Revision: D90536530